### PR TITLE
get-wurfl-2.1-db.sh is broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,7 @@ client.
 Installation
 ------------
 
-Installation is pegged to the latest GPL version of Wurfl.
-
-Assuming you're living in a virtualenv::
-
-    $ pip install -r requirements.pip
-    $ ./devproxy/etc/get-wurfl-2.1-db.sh
+    $ pip install device-proxy
 
 Running
 -------

--- a/devproxy/etc/config.yaml
+++ b/devproxy/etc/config.yaml
@@ -5,15 +5,44 @@ debug_path: /_debug
 health_path: /health
 
 handlers:
-  - wurfl: devproxy.handlers.wurfl_handler.simple.SimpleWurflHandler
+  - demo_handler: devproxy.handlers.demo.DemoHandler
+  # - scientia_mobile_handler: devproxy.handlers.wurfl_handler.ScientiaMobileCloudResolutionHandler
 
-wurfl:
-  # All keys in Memcached are prefixed with this
-  cache_prefix: devproxy
-  cache_lifetime: 100   # defaults to 0, which means it won't expire unless
-                        # memcached decides to delete the key based on its
-                        # least-recently-used counters when memory fills up.
-  # Connect to Memcached with the following parameters
+demo_handler:
+  cookies:
+    type: dog-biscuit
+
+scientia_mobile_handler:
   memcached:
     host: localhost
     port: 11211
+  cache_prefix: devproxy
+  cache_lifetime: 86400
+  smcloud_api_key: "your api key"
+
+# NOTE: Wurfl based approach deprecated.
+#       --------------------------------
+#
+#       Originally we provided a way of working with the old `wurfl.xml` file.
+#       However Luca and the friendly people at ScientiaMobile have gone
+#       through significant amount of trouble of having this file purged
+#       off of the the Internet. Leaving it here commented out for people
+#       who have a copy of the `wurfl.xml` file or who manage to find a
+#       workable copy somehere (check https://github.com/search?l=xml&q=wurfl.xml&ref=searchresults&type=Code)
+#
+#       We ship the ScientiaMobileCloudHandler for people who have purchased
+#       a licence with ScientiaMobile.
+#
+#  handlers:
+#   - wurfl: devproxy.handlers.wurfl_handler.simple.SimpleWurflHandler
+#
+# wurfl:
+#   # All keys in Memcached are prefixed with this
+#   cache_prefix: devproxy
+#   cache_lifetime: 100   # defaults to 0, which means it won't expire unless
+#                         # memcached decides to delete the key based on its
+#                         # least-recently-used counters when memory fills up.
+#   # Connect to Memcached with the following parameters
+#   memcached:
+#     host: localhost
+#     port: 11211

--- a/devproxy/etc/get-wurfl-2.1-db.sh
+++ b/devproxy/etc/get-wurfl-2.1-db.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-wget -c "http://mirror.transact.net.au/pub/sourceforge/w/project/wu/wurfl/WURFL/2.1.1/wurfl-2.1.zip"
-unzip -o "wurfl-2.1.zip" "wurfl.xml"
-wurfl2python.py -o "devproxy/handlers/wurfl_handler/wurfl_devices.py" "wurfl.xml"

--- a/devproxy/handlers/demo.py
+++ b/devproxy/handlers/demo.py
@@ -1,0 +1,51 @@
+# -*- test-case-name: devproxy.tests.test_demo -*-
+import collections
+
+from twisted.internet.defer import succeed
+
+from devproxy.handlers.base import BaseHandler, Cookie
+
+
+class DemoHandler(BaseHandler):
+
+    def validate_config(self, config):
+        """
+        Raise an error if something in the ``config`` dict isn't
+        what you were expecting it to be
+        """
+        if not isinstance(config.get('cookies'), collections.Mapping):
+            raise ValueError('Invalid `cookies` value in the config.')
+        self.cookies = config['cookies']
+
+    def setup_handler(self):
+        """
+        If your handler needs to connect to something external service
+        like Memcache, this is where you'd do that.
+
+        Needs to return a Deferred which returns `self`
+        """
+        return succeed(self)
+
+    def teardown_handler(self):
+        """
+        If your handler has things that need to be closed down properly.
+        Like a socket connection to some external service, this is where
+        you'd do that
+        """
+
+    def get_headers(self, request):
+        """
+        Return a list of dictionaries whose keys and values are to be
+        inserted into the request before being proxied upstream
+        """
+        return [{
+            'X-Device-Is-Dumb': 'Very'
+        }]
+
+    def get_cookies(self, request):
+        """
+        Return a list of Cookie instances to be inserted into the response
+        received from upstream before returning it to the client
+        """
+        return [Cookie(key, value)
+                for key, value in self.cookies.items()]

--- a/devproxy/handlers/wurfl_handler/__init__.py
+++ b/devproxy/handlers/wurfl_handler/__init__.py
@@ -1,0 +1,4 @@
+from devproxy.handlers.wurfl_handler.scientia_mobile_cloud_resolution import (
+    ScientiaMobileCloudResolutionHandler)
+
+__all__ = ['ScientiaMobileCloudResolutionHandler']

--- a/devproxy/tests/test_demo.py
+++ b/devproxy/tests/test_demo.py
@@ -1,0 +1,38 @@
+from twisted.internet.defer import inlineCallbacks
+
+from devproxy.tests.utils import ProxyTestCase
+from devproxy.utils import http
+from devproxy.handlers.demo import DemoHandler
+
+
+class DemoHandlerTestCase(ProxyTestCase):
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(DemoHandlerTestCase, self).setUp()
+        self.demo_handlers = yield self.start_handlers([DemoHandler({
+            'cookies': {
+                'type': 'dog-biscuit'
+            }
+        })])
+
+    @inlineCallbacks
+    def test_headers(self):
+        proxy, url = self.start_proxy(self.demo_handlers)
+        response = yield http.request(url)
+        self.assertEqual(response.delivered_body, 'foo')
+        req = yield self.mocked_backend.queue.get()
+        self.assertEqual(
+            req.requestHeaders.getRawHeaders('x-device-is-dumb'),
+            ['Very'])
+
+    @inlineCallbacks
+    def test_cookies(self):
+        proxy, url = self.start_proxy(self.demo_handlers)
+        resp = yield http.request(url, method='GET')
+        self.assertEqual(resp.delivered_body, 'foo')
+        req = yield self.mocked_backend.queue.get()
+        self.assertFalse(req.requestHeaders.hasHeader('Set-Cookie'))
+        self.assertTrue(resp.headers.hasHeader('Set-Cookie'))
+        self.assertEqual(resp.headers.getRawHeaders('Set-Cookie'), [
+            'type=dog-biscuit'])

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def listify(filename):
 
 setup(
     name="device-proxy",
-    version="0.1j",
+    version="0.2",
     url='http://github.com/praekelt/device-proxy',
     license='BSD',
     description="Device Proxy. A reverse HTTP Proxy that can inspect and "


### PR DESCRIPTION
The script statically points to http://mirror.transact.net.au/pub/sourceforge/w/project/wu/wurfl/WURFL/2.1.1/wurfl-2.1.zip which is not available. That files is also not available on sourceforge anywhere it seems. 
